### PR TITLE
feat: replace View All Posts button with pagination on Tech Blog page

### DIFF
--- a/frontend/app/components/LatestInsights.module.css
+++ b/frontend/app/components/LatestInsights.module.css
@@ -14,39 +14,42 @@
     width: 100%;
 }
 
-.buttonContainer {
-    width: 100%;
-    margin-top: 3rem;
-    box-sizing: border-box;
-    display: flex;
-    justify-content: center;
+/* ===== PAGINATION ===== */
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 3rem;
 }
 
-.viewAllButtonLink {
-    background: #a855f7;
-    color: white;
-    padding: 0.75rem 1.5rem;
-    border-radius: 0.75rem;
-    font-weight: 500;
-    font-size: 0.95rem;
-    border: none;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    transform: translateY(0);
-    text-decoration: none;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: auto;
-    box-sizing: border-box;
-     /* Prevent button overflow */
-    max-width: 100%;
+.pageBtn {
+  background: none;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.875rem;
+  font-size: 0.95rem;
+  font-family: inherit;
+  color: #374151;
+  cursor: pointer;
+  transition: all 0.2s ease;
 }
 
-.viewAllButtonLink:hover {
-    background: #9333ea;
-    box-shadow: 0 4px 12px rgba(168, 85, 247, 0.3);
-    transform: translateY(-1px);
+.pageBtn:hover:not(:disabled) {
+  border-color: #a855f7;
+  color: #a855f7;
+}
+
+.pageBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.activePage {
+  background: #a855f7;
+  border-color: #a855f7;
+  color: white;
+  font-weight: 600;
 }
 
 /* Tablet */

--- a/frontend/app/components/LatestInsights.tsx
+++ b/frontend/app/components/LatestInsights.tsx
@@ -1,24 +1,68 @@
-import React from "react";
+"use client"
+
+import React, { useState } from "react";
 import  Posts  from "../data/posts";
 import styles from  "./LatestInsights.module.css";
 import BlogPost from "./BlogPost";
-import Link from "next/link";
+
+
+const POSTS_PER_PAGE = 4;
 
 export default function LatestInsights() {
+    const [currentPage, setCurrentPage] = useState(1);
+
+    const totalPages = Math.ceil(Posts.length / POSTS_PER_PAGE);
+    const startIndex = (currentPage - 1) * POSTS_PER_PAGE;
+    const currentPosts = Posts.slice(startIndex, startIndex + POSTS_PER_PAGE);
+
+    const goToPage = (page: number) => {
+    if (page < 1 || page > totalPages) return;
+    setCurrentPage(page);
+  };
+
     return (
         <section className={styles.latesInsightsContainer}>   
             {/* Tech Blog Grid */}
             <div className={styles.blogGrid}>
-                {Posts.map((post) => (
+                {currentPosts.map((post) => (
                  <BlogPost key={post.id} post={post} />
                 ))} 
             </div>
-            <div className={styles.buttonContainer}>
-                    <Link href="/tech-blog" className={styles.viewAllButtonLink}>
-                        View all Posts
-                    </Link>
-            </div>
-        </section>
-    )
+            
+            {/* Pagination */}
+            <div className={styles.pagination}>
+
+            {/* Previous */}
+            <button
+                className={styles.pageBtn}
+                onClick={() => goToPage(currentPage - 1)}
+                disabled={currentPage === 1}
+            >
+                &lt; Previous
+            </button>
+
+            {/* Page Numbers */}
+            {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+            <button
+                key={page}
+                className={`${styles.pageBtn} ${currentPage === page ? styles.activePage : ""}`}
+                onClick={() => goToPage(page)}
+            >
+                {page}
+                </button>
+            ))}
+
+            {/* Next */}
+            <button
+                className={styles.pageBtn}
+                onClick={() => goToPage(currentPage + 1)}
+                disabled={currentPage === totalPages}
+            >
+                Next &gt;
+            </button>
+
+        </div>
+    </section>
+    );
 }
 


### PR DESCRIPTION
Replaces the static "View All Posts" button on the Tech Blog page with functional pagination.

**Changes:**

- Removed "View All Posts" button and its associated styles
- Added pagination (Previous / page numbers / Next) with active and disabled states
- Limited posts displayed to 4 per page using POSTS_PER_PAGE constant
- Converted LatestInsights to a client component to handle pagination state
- Fixed CSS typo: padding: 3 1.25rem → padding: 3rem 1.25rem

Result: Users can now navigate through blog posts page by page instead of being redirected to a separate route.