### PR TITLE
Fix: Hero button overlapping sticky navbar

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -16,7 +16,6 @@
   display: inline-flex;
   align-items: center;
   white-space: nowrap;
-  z-index: 1001;
 }
 
 .btn-primary:hover {


### PR DESCRIPTION
**Problem**

- "View AI Solutions" button rendered above the sticky navbar when scrolling, unlike "Download my Resume".

**Fix**

- Removed `z-index: 1001` from `.btn-primary` — flex items respect z-index even without `position` set, which was overriding the navbar's `z-index: 1000`.

Result
- Button now scrolls behind the navbar correctly, matching expected behavior.