### PR TITLE
 Add autoplay video to Lifestyle page

### DIFF
--- a/frontend/app/lifestyle/lifestyle.module.css
+++ b/frontend/app/lifestyle/lifestyle.module.css
@@ -38,6 +38,7 @@
     padding: 0.5rem;
     display: block;
     margin: 0 auto;
+    object-fit: cover;
 }
 
 .sectionTitle {

--- a/frontend/app/lifestyle/page.tsx
+++ b/frontend/app/lifestyle/page.tsx
@@ -1,8 +1,34 @@
-import React from "react";
+"use client";
+
+import React, { useEffect, useRef } from "react";
 import styles from "./lifestyle.module.css";
 
 
 const LifeStylePage: React.FC = () => {
+
+    const videoRef = useRef<HTMLVideoElement>(null);
+
+    useEffect(() => {
+        const video = videoRef.current;
+        if (!video) return;
+
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                if (entry.isIntersecting) {
+                    video.currentTime = 0;
+                    video.play().catch(() => {});
+                } else {
+                    video.pause();
+                }
+            },
+            { threshold: 0.5 }
+        );
+
+        observer.observe(video);
+
+        return () => observer.disconnect();
+    }, []);
+
     const practices = [
         {
             title: "Daily meditation and mindfulness practices",
@@ -69,10 +95,14 @@ const LifeStylePage: React.FC = () => {
                     </p>   
                     </div>
                     <div className={styles.imageContainer}>
-                        <img
-                            src="/images/work-life.jpg"
-                            alt="Work-Life in Tech"
+                        <video
+                            ref={videoRef}
+                            src="/videos/work-life.mp4"
                             className={styles.workLifeBalanceImage}
+                            muted
+                            playsInline
+                            preload="metadata"
+                            aria-label="Work-life integration in tech"
                         />
                     </div>
                 </section>


### PR DESCRIPTION
 **Problem**
The "Work-Life Integration in Tech" section used a static image — wanted a short video instead to make the section more engaging.

 **Changes**

- Replaced `<img>` with `<video>` (8s clip, muted, plays inline)
- Added `IntersectionObserver` to autoplay when scrolled into view (50% visible) and pause when scrolled away
- Video restarts from beginning each time it re-enters the viewport
- Added `object-fit: cover` to preserve existing image container sizing

 **Result**
Video plays automatically as the user scrolls to that section, pauses when out of view — no manual controls needed.