### PR TITLE
Add Projects link to navbar

### DIFF
--- a/frontend/app/components/Navbar.tsx
+++ b/frontend/app/components/Navbar.tsx
@@ -26,6 +26,9 @@ export default function Navbar() {
             <Link href="/about" className={styles.navLink} onClick={() => setOpen(false)}>About Me</Link>
           </li>
           <li>
+            <Link href="/projects" className={styles.navLink} onClick={() => setOpen(false)}>Projects</Link>
+          </li>
+          <li>
             <Link href="/tech-blog" className={styles.navLink} onClick={() => setOpen(false)}>Tech Blog</Link>
           </li>
           <li>
@@ -61,6 +64,10 @@ export default function Navbar() {
 
     <Link href="/about" className={styles.mobileLink} onClick={() => setOpen(false)}>
       About Me
+    </Link>
+
+    <Link href="/projects" className={styles.mobileLink} onClick={() => setOpen(false)}>
+      Projects
     </Link>
 
     <Link href="/tech-blog" className={styles.mobileLink} onClick={() => setOpen(false)}>


### PR DESCRIPTION
 **Why**
Part of the Projects Page issue — navbar needs a link to the new /projects route.

**Changes**
- Added "Projects" link to desktop navigation 
- Added matching link to mobile dropdown menu

**Result**
Navbar now includes a Projects link on both desktop and mobile, ready for the /projects page to be built.